### PR TITLE
Add support for Microsoft.VisualStudio.Community

### DIFF
--- a/ThemeToggler/source.extension.vsixmanifest
+++ b/ThemeToggler/source.extension.vsixmanifest
@@ -11,6 +11,9 @@
         <InstallationTarget Version="[17.0,18.0)" Id="Microsoft.VisualStudio.Pro">
             <ProductArchitecture>arm64</ProductArchitecture>
         </InstallationTarget>
+        <InstallationTarget Version="[17.0,18.0)" Id="Microsoft.VisualStudio.Community">
+            <ProductArchitecture>amd64</ProductArchitecture>
+        </InstallationTarget>
     </Installation>
     <Prerequisites>
         <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[17.0,)" DisplayName="Visual Studio core editor" />


### PR DESCRIPTION
Fixed error "VSIXInstaller.NoApplicableSKUsException: This extension is not installable on any currently installed products."